### PR TITLE
Add `skip_header` option

### DIFF
--- a/lib/csv_format/spec.ex
+++ b/lib/csv_format/spec.ex
@@ -8,10 +8,12 @@ defmodule CsvFormat.Spec do
       |> Enum.unzip()
 
     dumper = Keyword.fetch!(opts, :dumper)
+    skip_header = Keyword.get(opts, :skip_header, false)
 
     quote bind_quoted: [
             dumper: dumper,
             fields: fields,
+            skip_header: skip_header,
             titles: titles
           ] do
       spec_module = __MODULE__
@@ -22,6 +24,7 @@ defmodule CsvFormat.Spec do
         @fields fields
         @header [titles] |> dumper.dump_to_iodata() |> hd()
         @module spec_module
+        @skip_header skip_header
 
         if fields == [] do
           @spec new([%{atom() => term()}]) :: []
@@ -37,7 +40,11 @@ defmodule CsvFormat.Spec do
               |> @dumper.dump_to_stream()
               |> Enum.to_list()
 
-            [@header | rows]
+            if @skip_header do
+              rows
+            else
+              [@header | rows]
+            end
           end
         end
 

--- a/test/csv_format/spec_test.exs
+++ b/test/csv_format/spec_test.exs
@@ -32,10 +32,23 @@ defmodule CsvFormat.SpecTest do
     assert iodata_to_binary(csv) == ""
   end
 
-  test "a spec that takes no data should build headers only" do
+  test "a spec that takes no data should build header only" do
     csv = EmployeeCsv.Builder.new([])
 
     assert iodata_to_binary(csv) == "#,Role,First name,Last name\r\n"
+  end
+
+  test "a spec should not output header when `skip_header` is false" do
+    csv_without_rows = EmployeeCsvWithoutHeader.Builder.new([])
+
+    assert iodata_to_binary(csv_without_rows) == ""
+
+    csv_with_rows = EmployeeCsvWithoutHeader.Builder.new(@employees)
+
+    assert iodata_to_binary(csv_with_rows) == """
+           1,Software Engineer,Emma,Johnson\r\n\
+           2,Marketing Manager,Alex,Martinez\r\n\
+           """
   end
 
   test "a spec should build a csv with columns in order" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -23,6 +23,19 @@ defmodule EmployeeCsv do
     ]
 end
 
+defmodule EmployeeCsvWithoutHeader do
+  @moduledoc false
+  use CsvFormat.Spec,
+    dumper: NimbleCSV.RFC4180,
+    skip_header: true,
+    columns: [
+      id: "#",
+      role: "Role",
+      first_name: "First name",
+      last_name: "Last name"
+    ]
+end
+
 defmodule EmployeeCsvWithCustomColumn do
   @moduledoc false
   use CsvFormat.Spec,


### PR DESCRIPTION
Adds a `skip_header` option with a default value of `false`.

Example:

```elixir
defmodule EmployeeCsvWithoutHeader do
  @moduledoc false
  use CsvFormat.Spec,
    dumper: NimbleCSV.RFC4180,
    skip_header: true,
    columns: [
      id: "#",
      role: "Role",
      first_name: "First name",
      last_name: "Last name"
    ]
end

EmployeeCsvWithoutHeader.Builder.new(@employees)
```

Yields:

```csv
1,Software Engineer,Emma,Johnson\r\n\
2,Marketing Manager,Alex,Martinez\r\n\
```

